### PR TITLE
Polishing up the look and feel of existing pages

### DIFF
--- a/iris/static/css/base.css
+++ b/iris/static/css/base.css
@@ -1,5 +1,6 @@
 @import url(student_session.css);
 @import url(lecturer_session.css);
+@import url(security.css);
 
 body {
     background-color: #E3F2FD;

--- a/iris/static/css/base.css
+++ b/iris/static/css/base.css
@@ -31,7 +31,5 @@ main {
 
 .mdl-card__title {
     transition: 0.25s;
-    background-color: #2196F3;
-    color: #fff;
     height: 64px;
 }

--- a/iris/static/css/base.css
+++ b/iris/static/css/base.css
@@ -13,6 +13,7 @@ body {
 
 main {
     padding: 32px 0;
+    min-width: 1024px;
 }
 
 .mdl-cell .mdl-card {
@@ -20,8 +21,13 @@ main {
     min-height: inherit;
 }
 
+.mdl-card {
+    margin-bottom: 16px;
+}
+
 .mdl-card__title {
     transition: 0.25s;
     background-color: #2196F3;
     color: #fff;
+    height: 64px;
 }

--- a/iris/static/css/base.css
+++ b/iris/static/css/base.css
@@ -12,8 +12,12 @@ body {
 }
 
 main {
-    padding: 32px 0;
+    padding: 16px 0;
     min-width: 1024px;
+}
+
+.mdl-grid {
+    padding: 0;
 }
 
 .mdl-cell .mdl-card {

--- a/iris/static/css/lecturer_session.css
+++ b/iris/static/css/lecturer_session.css
@@ -1,9 +1,10 @@
 .counts {
-    display: flex;
+    /* display: flex;
     justify-content: center;
     border-top: 1px solid rgba(0, 0, 0, .1);
     border-bottom: 1px solid rgba(0, 0, 0, .1);
-    padding: 16px;
+    padding: 16px; */
+    display: none;
 }
 
 .counts span:not(:last-child) {

--- a/iris/static/css/lecturer_session.css
+++ b/iris/static/css/lecturer_session.css
@@ -12,5 +12,20 @@
 }
 
 canvas {
-    margin: 16px auto;
+    margin: 8px auto;
+}
+
+.questions-log {
+    border-top: 1px solid rgba(0,0,0,.1);
+    padding: 8px;
+    overflow-y: auto;
+    max-height: 700px;
+}
+
+.questions-log ul {
+    margin: 0;
+}
+
+.questions-log .mdl-list__item {
+    padding: 8px;
 }

--- a/iris/static/css/security.css
+++ b/iris/static/css/security.css
@@ -1,0 +1,13 @@
+.login-form {
+    padding: 8px;
+}
+
+.login-form .mdl-textfield{
+    display: block;
+    width: 100%;
+}
+
+hr {
+    margin: 16px -16px;
+    border-top-color: rgba(0, 0, 0, 0.1);
+}

--- a/iris/static/css/student_session.css
+++ b/iris/static/css/student_session.css
@@ -7,4 +7,36 @@
 .feedback button {
     margin: 4px;
     width: calc(50% - 8px);
+    height: 64px;
+}
+
+.question-ask {
+    margin: 4px;
+}
+
+.question-ask .mdl-textfield {
+    width: 100%;
+}
+
+.question-ask textarea {
+    max-height: 285px;
+}
+
+.question-ask button {
+    width: 100%;
+}
+
+.questions-log {
+    border-top: 1px solid rgba(0,0,0,.1);
+    padding: 8px;
+    overflow-y: auto;
+    max-height: 673px;
+}
+
+.questions-log ul {
+    margin: 0;
+}
+
+.questions-log .mdl-list__item {
+    padding: 8px;
 }

--- a/iris/static/css/student_session.css
+++ b/iris/static/css/student_session.css
@@ -19,7 +19,7 @@
 }
 
 .question-ask textarea {
-    max-height: 285px;
+    max-height: 312px;
 }
 
 .question-ask button {
@@ -30,7 +30,6 @@
     border-top: 1px solid rgba(0,0,0,.1);
     padding: 8px;
     overflow-y: auto;
-    max-height: 673px;
 }
 
 .questions-log ul {

--- a/iris/static/css/student_session.css
+++ b/iris/static/css/student_session.css
@@ -30,6 +30,7 @@
     border-top: 1px solid rgba(0,0,0,.1);
     padding: 8px;
     overflow-y: auto;
+    max-height: 700px;
 }
 
 .questions-log ul {

--- a/iris/static/js/lecturer_session.js
+++ b/iris/static/js/lecturer_session.js
@@ -54,7 +54,7 @@ socket.on('lecturer_recv', function (msg) {
       difficulty.update()
     }
   } else if (msg.hasOwnProperty('question')) {
-    $('#questions').prepend('<li class="mdl-list__item-text-body"><span class="mdl-list__item-primary-content"><i class="material-icons mdl-list__item-icon">person</i>' + msg['question'] + '</span></li>')
+    $('#questions').prepend('<li class="mdl-list__item"><span class="mdl-list__item-primary-content"><i class="material-icons mdl-list__item-icon">person</i>' + msg['question'] + '</span></li>')
   } else if (msg.hasOwnProperty('active')) {
     console.log(msg['active'])
     if (msg['active']) {

--- a/iris/static/js/lecturer_session.js
+++ b/iris/static/js/lecturer_session.js
@@ -88,6 +88,9 @@ let speed = new Chart(ctxSpeed, {
       'Slow',
       'Fast'
     ]
+  },
+  options: {
+    responsive: false
   }
 })
 
@@ -110,5 +113,8 @@ let difficulty = new Chart(ctxDifficulty, {
       'Easy',
       'Hard'
     ]
+  },
+  options: {
+    responsive: false
   }
 })

--- a/iris/static/js/lecturer_session.js
+++ b/iris/static/js/lecturer_session.js
@@ -1,21 +1,16 @@
 const buttonStart = document.getElementById('button_start')
 const buttonStop = document.getElementById('button_stop')
-const cardTitle = document.getElementById('card_title')
 let socket = io()
 socket.emit('join', {'course_id': courseID})
 
 function disableStart () {
   buttonStart.disabled = true
   buttonStop.disabled = false
-  cardTitle.innerHTML = 'Session active'
-  $('.mdl-card__title').css('background-color', '#E91E63')
 }
 
 function disableStop () {
   buttonStart.disabled = false
   buttonStop.disabled = true
-  cardTitle.innerHTML = 'Session not active'
-  $('.mdl-card__title').css('background-color', '#2196F3')
 }
 
 if (sessionActive) {

--- a/iris/static/js/student_session.js
+++ b/iris/static/js/student_session.js
@@ -138,7 +138,7 @@ socket.on('student_recv', function (msg) {
   let receivedStatus = msg.hasOwnProperty('active')
   console.log(receivedStatus)
   if (!receivedStatus) {
-    $('#questions').prepend('<li class="mdl-list__item-text-body"><span class="mdl-list__item-primary-content"><i class="material-icons mdl-list__item-icon">person</i>' + msg['question'] + '</span></li>')
+    $('#questions').prepend('<li class="mdl-list__item"><span class="mdl-list__item-primary-content"><i class="material-icons mdl-list__item-icon">person</i>' + msg['question'] + '</span></li>')
   }
   if (msg.hasOwnProperty('command')) {
     if (msg['command'] === 'deleteQuestions') {

--- a/iris/static/js/student_session.js
+++ b/iris/static/js/student_session.js
@@ -155,3 +155,11 @@ socket.on('student_recv', function (msg) {
     }
   }
 })
+
+// Disable questionInput newline on enter, unless shift+enter is used
+$('textarea').keydown(function (e) {
+  if (e.keyCode === 13 && !e.shiftKey) {
+    e.preventDefault()
+    questionButton.click()
+  }
+})

--- a/iris/templates/lecturer_session.html
+++ b/iris/templates/lecturer_session.html
@@ -33,26 +33,7 @@
         </div>
     </div>
     <div class="mdl-cell mdl-cell--6-col mdl-cell--4-col-tablet mdl-cell--4-col-phone">
-        <div class="mdl-card mdl-shadow--2dp questions-card">
-            <div class="mdl-card__title mdl-color--primary mdl-color-text--white">
-                <h2 class="mdl-card__title-text">Asked questions</h2>
-            </div>
-            <div class="mdl-card__supporting-text">
-                Here are the questions that have already been asked by you and your peers!
-            </div>
-            <div class="questions-log">
-                <ul class="mdl-list" id="questions">
-                    {% for q in questions %}
-                        <li class="mdl-list__item">
-                                <span class="mdl-list__item-primary-content">
-                                    <i class="material-icons mdl-list__item-icon">person</i>
-                                    {{ q.question }}
-                                </span>
-                        </li>
-                    {% endfor %}
-                </ul>
-            </div>
-        </div>
+        {% include 'question_log.html' %}
     </div>
 {% endblock content %}
 

--- a/iris/templates/lecturer_session.html
+++ b/iris/templates/lecturer_session.html
@@ -4,7 +4,7 @@
 {% block content %}
     <div class="mdl-cell mdl-cell--4-col mdl-cell--2-col-tablet mdl-cell--4-col-phone mdl-cell--1-offset mdl-cell--1-offset-tablet">
         <div class="mdl-card mdl-shadow--2dp">
-            <div class="mdl-card__title">
+            <div class="mdl-card__title mdl-color--primary mdl-color-text--white">
                 <h2 id="card_title" class="mdl-card__title-text">Lecture Controls</h2>
             </div>
             <div class="mdl-card__supporting-text">
@@ -34,7 +34,7 @@
     </div>
     <div class="mdl-cell mdl-cell--6-col mdl-cell--4-col-tablet mdl-cell--4-col-phone">
         <div class="mdl-card mdl-shadow--2dp questions-card">
-            <div class="mdl-card__title">
+            <div class="mdl-card__title mdl-color--primary mdl-color-text--white">
                 <h2 class="mdl-card__title-text">Asked questions</h2>
             </div>
             <div class="mdl-card__supporting-text">

--- a/iris/templates/lecturer_session.html
+++ b/iris/templates/lecturer_session.html
@@ -11,10 +11,12 @@
                 You may start and/or stop a feedback session using the buttons below!
             </div>
             <div class="mdl-card__actions mdl-card--border">
-                <button id="button_start" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--primary">
+                <button id="button_start"
+                        class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--primary">
                     Start
                 </button>
-                <button id="button_stop" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
+                <button id="button_stop"
+                        class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
                     Stop
                 </button>
             </div>
@@ -33,7 +35,9 @@
         </div>
     </div>
     <div class="mdl-cell mdl-cell--6-col mdl-cell--4-col-tablet mdl-cell--4-col-phone">
-        {% include 'question_log.html' %}
+        {% with msg = 'Here are the questions asked by your students!' %}
+            {% include 'question_log.html' %}
+        {% endwith %}
     </div>
 {% endblock content %}
 

--- a/iris/templates/lecturer_session.html
+++ b/iris/templates/lecturer_session.html
@@ -2,7 +2,7 @@
 {% block title %}IRIS - session{% endblock title %}
 
 {% block content %}
-    <div class="mdl-cell mdl-cell--6-col mdl-cell--6-col-tablet mdl-cell--4-col-phone mdl-cell--3-offset mdl-cell--2-offset-tablet">
+    <div class="mdl-cell mdl-cell--4-col mdl-cell--2-col-tablet mdl-cell--4-col-phone mdl-cell--1-offset mdl-cell--1-offset-tablet">
         <div class="mdl-card mdl-shadow--2dp">
             <div class="mdl-card__title mdl-card--expand">
                 <h2 id="card_title" class="mdl-card__title-text">Lecture Controls</h2>
@@ -24,30 +24,34 @@
                 <span id="text_easy" class="mdl-badge" data-badge="{{ counts['easy'] }}">Easy</span>
                 <span id="text_hard" class="mdl-badge" data-badge="{{ counts['hard'] }}">Hard</span>
             </div>
-            <div class="mdl-card__actions mdl-card--border feedback">
-                <div style="height:auto; overflow:auto;">
-                    <ul class="question-list-item mdl-list" id="questions">
-                        {% for q in questions %}
-                            <li class="mdl-list__item-text-body">
+        </div>
+        <div class="mdl-card mdl-shadow--2dp chart">
+            <canvas id="speed"></canvas>
+        </div>
+        <div class="mdl-card mdl-shadow--2dp chart">
+            <canvas id="difficulty"></canvas>
+        </div>
+    </div>
+    <div class="mdl-cell mdl-cell--6-col mdl-cell--4-col-tablet mdl-cell--4-col-phone">
+        <div class="mdl-card mdl-shadow--2dp questions-card">
+            <div class="mdl-card__title">
+                <h2 class="mdl-card__title-text">Asked questions</h2>
+            </div>
+            <div class="mdl-card__supporting-text">
+                Here are the questions that have already been asked by you and your peers!
+            </div>
+            <div class="questions-log">
+                <ul class="mdl-list" id="questions">
+                    {% for q in questions %}
+                        <li class="mdl-list__item">
                                 <span class="mdl-list__item-primary-content">
                                     <i class="material-icons mdl-list__item-icon">person</i>
                                     {{ q.question }}
                                 </span>
-                            </li>
-                        {% endfor %}
-                    </ul>
-                </div>
+                        </li>
+                    {% endfor %}
+                </ul>
             </div>
-        </div>
-    </div>
-    <div class="mdl-cell mdl-cell--3-col mdl-cell--3-col-tablet mdl-cell--2-col-phone mdl-cell--3-offset mdl-cell--1-offset-tablet">
-        <div class="mdl-card mdl-shadow--2dp">
-            <canvas id="speed"></canvas>
-        </div>
-    </div>
-    <div class="mdl-cell mdl-cell--3-col mdl-cell--3-col-tablet mdl-cell--2-col-phone">
-        <div class="mdl-card mdl-shadow--2dp">
-            <canvas id="difficulty"></canvas>
         </div>
     </div>
 {% endblock content %}

--- a/iris/templates/lecturer_session.html
+++ b/iris/templates/lecturer_session.html
@@ -4,17 +4,17 @@
 {% block content %}
     <div class="mdl-cell mdl-cell--4-col mdl-cell--2-col-tablet mdl-cell--4-col-phone mdl-cell--1-offset mdl-cell--1-offset-tablet">
         <div class="mdl-card mdl-shadow--2dp">
-            <div class="mdl-card__title mdl-card--expand">
+            <div class="mdl-card__title">
                 <h2 id="card_title" class="mdl-card__title-text">Lecture Controls</h2>
             </div>
             <div class="mdl-card__supporting-text">
                 You may start and/or stop a feedback session using the buttons below!
             </div>
             <div class="mdl-card__actions mdl-card--border">
-                <button id="button_start" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect">
+                <button id="button_start" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--primary">
                     Start
                 </button>
-                <button id="button_stop" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect">
+                <button id="button_stop" class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">
                     Stop
                 </button>
             </div>

--- a/iris/templates/question_log.html
+++ b/iris/templates/question_log.html
@@ -1,0 +1,20 @@
+<div class="mdl-card mdl-shadow--2dp questions-card">
+    <div class="mdl-card__title mdl-color--primary mdl-color-text--white">
+        <h2 class="mdl-card__title-text">Asked questions</h2>
+    </div>
+    <div class="mdl-card__supporting-text">
+        Here are the questions that have been asked by the students!
+    </div>
+    <div class="questions-log">
+        <ul class="mdl-list" id="questions">
+            {% for q in questions %}
+                <li class="mdl-list__item">
+                    <span class="mdl-list__item-primary-content">
+                        <i class="material-icons mdl-list__item-icon">person</i>
+                        {{ q.question }}
+                    </span>
+                </li>
+            {% endfor %}
+        </ul>
+    </div>
+</div>

--- a/iris/templates/question_log.html
+++ b/iris/templates/question_log.html
@@ -3,7 +3,7 @@
         <h2 class="mdl-card__title-text">Asked questions</h2>
     </div>
     <div class="mdl-card__supporting-text">
-        Here are the questions that have been asked by the students!
+        {{ msg }}
     </div>
     <div class="questions-log">
         <ul class="mdl-list" id="questions">

--- a/iris/templates/security/login_user.html
+++ b/iris/templates/security/login_user.html
@@ -2,7 +2,7 @@
 {% block title %} IRIS - login {% endblock title %}
 
 {% block content %}
-    <div class="mdl-cell mdl-cell--6-col mdl-cell--6-col-tablet mdl-cell--4-col-phone mdl-cell--3-offset mdl-cell--2-offset-tablet">
+    <div class="mdl-cell mdl-cell--4-col mdl-cell--4-col-tablet mdl-cell--4-col-phone mdl-cell--4-offset mdl-cell--2-offset-tablet">
         <div class="mdl-card mdl-shadow--2dp">
             <div class="mdl-card__title mdl-color--primary mdl-color-text--white">
                 <h2 id="card_title" class="mdl-card__title-text">Lecturer login</h2>
@@ -16,11 +16,12 @@
                             {% endfor %}
                         </div>
                     {% else %}
-                        Please fill in your login information below
+                        <h5>Please fill in your login information below</h5>
                     {% endif %}
                 {%- endwith %}
-
-                <form action="{{ url_for_security('login') }}" method="POST" name="login_user_form">
+            </div>
+            <div class="mdl-card__actions mdl-card--border">
+                <form action="{{ url_for_security('login') }}" method="POST" name="login_user_form" class="login-form">
                     {{ login_user_form.hidden_tag() }}
                     <div class="mdl-textfield mdl-js-textfield">
                         <label class="mdl-textfield__label" for="{{ login_user_form.email.id }}">Email</label>
@@ -42,10 +43,13 @@
                             {% endfor %}
                         {% endif %}
                     </div>
-                    <div class="mdl-card__actions mdl-card--border">
-                        <input type="submit" class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect"
+                    <div class="actions">
+                        <hr/>
+                        <input type="submit"
+                               class="mdl-button mdl-button--raised mdl-js-button mdl-js-ripple-effect mdl-button--accent"
                                value="Log in"/>
-                        <a class="mdl-navigation__link" href="{{ url_for('security.register') }}">Register user</a>
+                        <a class="mdl-button mdl-button--primary" href="{{ url_for('security.register') }}">Register
+                            user</a>
                     </div>
                 </form>
             </div>

--- a/iris/templates/security/login_user.html
+++ b/iris/templates/security/login_user.html
@@ -4,7 +4,7 @@
 {% block content %}
     <div class="mdl-cell mdl-cell--6-col mdl-cell--6-col-tablet mdl-cell--4-col-phone mdl-cell--3-offset mdl-cell--2-offset-tablet">
         <div class="mdl-card mdl-shadow--2dp">
-            <div class="mdl-card__title mdl-card--expand">
+            <div class="mdl-card__title">
                 <h2 id="card_title" class="mdl-card__title-text">Lecturer login</h2>
             </div>
             <div class="mdl-card__supporting-text">

--- a/iris/templates/security/login_user.html
+++ b/iris/templates/security/login_user.html
@@ -4,7 +4,7 @@
 {% block content %}
     <div class="mdl-cell mdl-cell--6-col mdl-cell--6-col-tablet mdl-cell--4-col-phone mdl-cell--3-offset mdl-cell--2-offset-tablet">
         <div class="mdl-card mdl-shadow--2dp">
-            <div class="mdl-card__title">
+            <div class="mdl-card__title mdl-color--primary mdl-color-text--white">
                 <h2 id="card_title" class="mdl-card__title-text">Lecturer login</h2>
             </div>
             <div class="mdl-card__supporting-text">

--- a/iris/templates/security/login_user.html
+++ b/iris/templates/security/login_user.html
@@ -24,7 +24,7 @@
                     {{ login_user_form.hidden_tag() }}
                     <div class="mdl-textfield mdl-js-textfield">
                         <label class="mdl-textfield__label" for="{{ login_user_form.email.id }}">Email</label>
-                        <input class="mdl-textfield__input" type="text" name="{{ login_user_form.email.name }}"
+                        <input class="mdl-textfield__input" type="email" name="{{ login_user_form.email.name }}"
                                id="{{ login_user_form.email.id }}"/>
                         {% if login_user_form.email.errors %}
                             {% for error in login_user_form.email.errors %}

--- a/iris/templates/security/register_user.html
+++ b/iris/templates/security/register_user.html
@@ -4,7 +4,7 @@
 {% block content %}
     <div class="mdl-cell mdl-cell--6-col mdl-cell--6-col-tablet mdl-cell--4-col-phone mdl-cell--3-offset mdl-cell--2-offset-tablet">
         <div class="mdl-card mdl-shadow--2dp">
-            <div class="mdl-card__title mdl-card--expand">
+            <div class="mdl-card__title">
                 <h2 id="card_title" class="mdl-card__title-text">Lecturer register</h2>
             </div>
             <div class="mdl-card__supporting-text">

--- a/iris/templates/security/register_user.html
+++ b/iris/templates/security/register_user.html
@@ -2,7 +2,7 @@
 {% block title %} IRIS - register {% endblock title %}
 
 {% block content %}
-    <div class="mdl-cell mdl-cell--6-col mdl-cell--6-col-tablet mdl-cell--4-col-phone mdl-cell--3-offset mdl-cell--2-offset-tablet">
+    <div class="mdl-cell mdl-cell--4-col mdl-cell--4-col-tablet mdl-cell--4-col-phone mdl-cell--4-offset mdl-cell--2-offset-tablet">
         <div class="mdl-card mdl-shadow--2dp">
             <div class="mdl-card__title mdl-color--primary mdl-color-text--white">
                 <h2 id="card_title" class="mdl-card__title-text">Lecturer register</h2>
@@ -16,11 +16,14 @@
                             {% endfor %}
                         </div>
                     {% else %}
-                        Please fill in your register information below
+                        <h5>Please fill in your register information below</h5>
                     {% endif %}
                 {%- endwith %}
+            </div>
+            <div class="mdl-card__actions mdl-card--border">
 
-                <form action="{{ url_for_security('register') }}" method="POST" name="register_user_form">
+                <form action="{{ url_for_security('register') }}" method="POST" name="register_user_form"
+                      class="login-form">
                     {{ register_user_form.hidden_tag() }}
                     <div class="mdl-textfield mdl-js-textfield">
                         <label class="mdl-textfield__label" for="{{ register_user_form.email.id }}">Email</label>
@@ -54,8 +57,10 @@
                             {% endfor %}
                         {% endif %}
                     </div>
-                    <div class="mdl-card__actions mdl-card--border">
-                        <input type="submit" class="mdl-button mdl-button--colored mdl-js-button mdl-js-ripple-effect"
+                    <div class="actions">
+                        <hr/>
+                        <input type="submit"
+                               class="mdl-button mdl-button--raised mdl-button--accent mdl-js-button mdl-js-ripple-effect"
                                value="Register"/>
                     </div>
                 </form>

--- a/iris/templates/security/register_user.html
+++ b/iris/templates/security/register_user.html
@@ -4,7 +4,7 @@
 {% block content %}
     <div class="mdl-cell mdl-cell--6-col mdl-cell--6-col-tablet mdl-cell--4-col-phone mdl-cell--3-offset mdl-cell--2-offset-tablet">
         <div class="mdl-card mdl-shadow--2dp">
-            <div class="mdl-card__title">
+            <div class="mdl-card__title mdl-color--primary mdl-color-text--white">
                 <h2 id="card_title" class="mdl-card__title-text">Lecturer register</h2>
             </div>
             <div class="mdl-card__supporting-text">

--- a/iris/templates/security/register_user.html
+++ b/iris/templates/security/register_user.html
@@ -24,7 +24,7 @@
                     {{ register_user_form.hidden_tag() }}
                     <div class="mdl-textfield mdl-js-textfield">
                         <label class="mdl-textfield__label" for="{{ register_user_form.email.id }}">Email</label>
-                        <input class="mdl-textfield__input" type="text" name="{{ register_user_form.email.name }}"
+                        <input class="mdl-textfield__input" type="email" name="{{ register_user_form.email.name }}"
                                id="{{ register_user_form.email.id }}"/>
                         {% if register_user_form.email.errors %}
                             {% for error in register_user_form.email.errors %}

--- a/iris/templates/student_session.html
+++ b/iris/templates/student_session.html
@@ -38,7 +38,9 @@
         </div>
     </div>
     <div class="mdl-cell mdl-cell--6-col mdl-cell--4-col-tablet mdl-cell--4-col-phone">
-        {% include 'question_log.html' %}
+        {% with msg = 'Here are the questions already asked by you and your peers!' %}
+            {% include 'question_log.html' %}
+        {% endwith %}
     </div>
 {% endblock content %}
 

--- a/iris/templates/student_session.html
+++ b/iris/templates/student_session.html
@@ -2,9 +2,9 @@
 {% block title %}IRIS - student{% endblock title %}
 
 {% block content %}
-    <div class="mdl-cell mdl-cell--6-col mdl-cell--6-col-tablet mdl-cell--4-col-phone mdl-cell--3-offset mdl-cell--2-offset-tablet">
+    <div class="mdl-cell mdl-cell--4-col mdl-cell--2-col-tablet mdl-cell--4-col-phone mdl-cell--1-offset mdl-cell--1-offset-tablet">
         <div class="mdl-card mdl-shadow--2dp">
-            <div class="mdl-card__title mdl-card--expand">
+            <div class="mdl-card__title">
                 <h2 class="mdl-card__title-text">Lecture Feedback</h2>
             </div>
             <div class="mdl-card__supporting-text">
@@ -13,13 +13,21 @@
             <div class="mdl-card__actions mdl-card--border feedback">
                 {% for action in actions %}
                     <button id="{{ action[0] }}"
-                            class="action_button mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect">{{ action[1] }}</button>
+                            class="action_button mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent">{{ action[1] }}</button>
                 {% endfor %}
             </div>
-            <div class="mdl-card__actions mdl-card--border feedback">
-                <form action="">
+        </div>
+        <div class="mdl-card mdl-shadow--2dp">
+            <div class="mdl-card__title">
+                <h2 class="mdl-card__title-text">Ask a question!</h2>
+            </div>
+            <div class="mdl-card__supporting-text">
+                Ask the lecturer a question!
+            </div>
+            <div class="mdl-card__actions mdl-card--border">
+                <form action="" class="question-ask">
                     <div class="mdl-textfield mdl-js-textfield">
-                        <textarea class="mdl-textfield__input" type="text" rows="3" id="questionInput"></textarea>
+                        <textarea class="mdl-textfield__input" type="text" rows="1" id="questionInput"></textarea>
                         <label class="mdl-textfield__label" for="questionInput">Ask a question</label>
                     </div>
                     <button class="mdl-button mdl-js-button mdl-button--raised mdl-js-ripple-effect mdl-button--accent"
@@ -27,19 +35,27 @@
                     </button>
                 </form>
             </div>
-            <div class="mdl-card__actions mdl-card--border feedback">
-                <div style="height:auto; overflow:auto;">
-                    <ul class="question-list-item mdl-list" id="questions">
-                        {% for q in questions %}
-                            <li class="mdl-list__item-text-body">
+        </div>
+    </div>
+    <div class="mdl-cell mdl-cell--6-col mdl-cell--4-col-tablet mdl-cell--4-col-phone">
+        <div class="mdl-card mdl-shadow--2dp">
+            <div class="mdl-card__title">
+                <h2 class="mdl-card__title-text">Asked questions</h2>
+            </div>
+            <div class="mdl-card__supporting-text">
+                Here are the questions that have already been asked by you and your peers!
+            </div>
+            <div class="questions-log">
+                <ul class="mdl-list" id="questions">
+                    {% for q in questions %}
+                        <li class="mdl-list__item">
                                 <span class="mdl-list__item-primary-content">
                                     <i class="material-icons mdl-list__item-icon">person</i>
                                     {{ q.question }}
                                 </span>
-                            </li>
-                        {% endfor %}
-                    </ul>
-                </div>
+                        </li>
+                    {% endfor %}
+                </ul>
             </div>
         </div>
     </div>

--- a/iris/templates/student_session.html
+++ b/iris/templates/student_session.html
@@ -4,7 +4,7 @@
 {% block content %}
     <div class="mdl-cell mdl-cell--4-col mdl-cell--2-col-tablet mdl-cell--4-col-phone mdl-cell--1-offset mdl-cell--1-offset-tablet">
         <div class="mdl-card mdl-shadow--2dp">
-            <div class="mdl-card__title">
+            <div class="mdl-card__title mdl-color--primary mdl-color-text--white">
                 <h2 class="mdl-card__title-text">Lecture Feedback</h2>
             </div>
             <div class="mdl-card__supporting-text">
@@ -18,7 +18,7 @@
             </div>
         </div>
         <div class="mdl-card mdl-shadow--2dp">
-            <div class="mdl-card__title">
+            <div class="mdl-card__title mdl-color--primary mdl-color-text--white">
                 <h2 class="mdl-card__title-text">Ask a question!</h2>
             </div>
             <div class="mdl-card__supporting-text">
@@ -39,7 +39,7 @@
     </div>
     <div class="mdl-cell mdl-cell--6-col mdl-cell--4-col-tablet mdl-cell--4-col-phone">
         <div class="mdl-card mdl-shadow--2dp">
-            <div class="mdl-card__title">
+            <div class="mdl-card__title mdl-color--primary mdl-color-text--white">
                 <h2 class="mdl-card__title-text">Asked questions</h2>
             </div>
             <div class="mdl-card__supporting-text">

--- a/iris/templates/student_session.html
+++ b/iris/templates/student_session.html
@@ -38,26 +38,7 @@
         </div>
     </div>
     <div class="mdl-cell mdl-cell--6-col mdl-cell--4-col-tablet mdl-cell--4-col-phone">
-        <div class="mdl-card mdl-shadow--2dp">
-            <div class="mdl-card__title mdl-color--primary mdl-color-text--white">
-                <h2 class="mdl-card__title-text">Asked questions</h2>
-            </div>
-            <div class="mdl-card__supporting-text">
-                Here are the questions that have already been asked by you and your peers!
-            </div>
-            <div class="questions-log">
-                <ul class="mdl-list" id="questions">
-                    {% for q in questions %}
-                        <li class="mdl-list__item">
-                                <span class="mdl-list__item-primary-content">
-                                    <i class="material-icons mdl-list__item-icon">person</i>
-                                    {{ q.question }}
-                                </span>
-                        </li>
-                    {% endfor %}
-                </ul>
-            </div>
-        </div>
+        {% include 'question_log.html' %}
     </div>
 {% endblock content %}
 


### PR DESCRIPTION
Marked this as a delight as it wasn't really _needed_, but some polish goes a long way for the overall user experience. 
In summary I restructured the student and lecturer session pages to be split into more cards, and tried my very best at keeping some sort of size consistency. I cleaned up the security pages a bit too, for what it's worth. Removed some redundancy here and there, tried to fix some bad practices, all that jazz. 
![It works on my machine!](https://cloud.githubusercontent.com/assets/14059677/24107372/d5052bce-0d8a-11e7-927b-a2370cfc288d.png)

